### PR TITLE
Footer legal links

### DIFF
--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -49,22 +49,6 @@ export default function Footer() {
               Blog
             </a>
           </li>
-            <li className="mb-2">
-            <a
-              href="/privacypolicy.html"
-              className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out"
-            >
-              Privacy Notice
-            </a>
-          </li>
-          <li className="mb-2">
-            <a
-              href="/tou.html"
-              className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out"
-            >
-              Terms of Use
-            </a>
-          </li>
         </ul>
       </div>
 
@@ -93,7 +77,7 @@ export default function Footer() {
 
       {/* 4th block */}
       <div className="sm:col-span-12 md:col-span-6 lg:col-span-4">
-        <h6 className="text-[#FFFFFF] font-bold mb-2">Guidelines</h6>
+        <h6 className="text-[#FFFFFF] font-bold mb-2">Guidelines & Legal</h6>
         <ul className="text-sm">
           <li className="mb-2">
             <a href="/PPF_Governance_Neutrality_Policy_greyscale_blackheader.html"
@@ -109,6 +93,16 @@ export default function Footer() {
           <li className="mb-2">
             <a href="/PPF_DAO_Governance_Participation_Disclaimer_greyscale_blackheader.html" className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out">
               DAO Governance Disclaimer
+            </a>
+          </li>
+          <li className="mb-2">
+            <a href="/privacypolicy.html" className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out">
+              Privacy Notice
+            </a>
+          </li>
+          <li className="mb-2">
+            <a href="/tou.html" className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out">
+              Terms of Use
             </a>
           </li>
         </ul>
@@ -159,12 +153,6 @@ export default function Footer() {
                   <li className="mb-2">
                     <a href="https://blog.pantherprotocol.io/" className="text-[#FFFFFF] text-[12px] hover:text-gray-900 transition duration-150 ease-in-out">Blog</a>
                   </li>
-                  <li className="mb-2">
-                    <a href="/privacypolicy.html" className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out">Privacy Notice</a>
-                  </li>
-                  <li className="mb-2">
-                    <a href="/tou.html" className="text-[#FFFFFF] text-[12px] hover:text-gray-300 transition duration-150 ease-in-out">Terms of Use</a>
-                  </li>
 
                 </ul>
               </div>
@@ -186,7 +174,7 @@ export default function Footer() {
 
               {/* 4th block */}
               <div className="ml-[20em] w-[20em]">
-                <h6 className="text-[#FFFFFF]  font-bold mb-2">Guidelines</h6>
+                <h6 className="text-[#FFFFFF]  font-bold mb-2">Guidelines & Legal</h6>
                 <ul className="text-sm">
                   <li className="mb-2">
                     <a href="/PPF_Governance_Neutrality_Policy_greyscale_blackheader.html" className="text-[#FFFFFF] text-[12px] w-[30em] hover:text-gray-900 transition duration-150 ease-in-out">Governance Neutrality Policy</a>
@@ -196,6 +184,12 @@ export default function Footer() {
                   </li>
                   <li className="mb-2">
                     <a href="/PPF_DAO_Governance_Participation_Disclaimer_greyscale_blackheader.html" className="text-[#FFFFFF] text-[12px] w-[30em] hover:text-gray-900 transition duration-150 ease-in-out">DAO Governance Disclaimer</a>
+                  </li>
+                  <li className="mb-2">
+                    <a href="/privacypolicy.html" className="text-[#FFFFFF] text-[12px] w-[30em] hover:text-gray-900 transition duration-150 ease-in-out">Privacy Notice</a>
+                  </li>
+                  <li className="mb-2">
+                    <a href="/tou.html" className="text-[#FFFFFF] text-[12px] w-[30em] hover:text-gray-900 transition duration-150 ease-in-out">Terms of Use</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
Move 'Privacy Notice' and 'Terms of Use' links to the 'Guidelines & Legal' column in the footer, and rename the column header, to better organize legal information.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1f8dd0ae-0120-4cde-ba5c-18ebb1e95323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f8dd0ae-0120-4cde-ba5c-18ebb1e95323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

