### PR TITLE
Fix mobile footer links unclickable: FeaturesBlocks overflow was cove…

### DIFF
--- a/components/features-blocks.tsx
+++ b/components/features-blocks.tsx
@@ -10,7 +10,7 @@ import Link from 'next/link';
 export default function FeaturesBlocks() {
   return (
 
-    <><section className="relative h-[150em] mobile">
+    <><section className="relative h-[150em] mobile overflow-hidden">
 
       {/* Section background (needs .relative class on parent and next sibling elements) */}
       <div className="absolute h-[100em] inset-0 top-1/2 md:mt-20 lg:mt-0  pointer-events-none" aria-hidden="true"></div>

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -9,7 +9,7 @@ import Link from 'next/link';
 export default function Footer() {
   return (
 
-    <><footer className='mobile '>
+    <><footer className='mobile relative z-10'>
      <div className="max-w-[100vw] bg-[#1E1E1E] mx-auto px-4 sm:px-6">
   <div className="max-w-6xl bg-[#1E1E1E] mx-auto px-4 sm:px-6">
 


### PR DESCRIPTION
…ring the footer

Root cause: The FeaturesBlocks mobile section had h-[150em] on the <section>
but its inner content div had h-[185em], overflowing by 35em. This overflow content sat directly on top of the footer in the DOM, intercepting all click/tap events and making footer links impossible to click on mobile.

Fix:
- Add overflow-hidden to the FeaturesBlocks mobile section to clip the overflowing content
- Add relative z-10 to the mobile footer so it renders above any stray overlap from content sections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts overflow and stacking order on mobile; main risk is minor layout clipping or z-index side effects.
> 
> **Overview**
> Fixes an issue where the mobile `FeaturesBlocks` section could visually/interaction-wise overlap the footer and intercept taps.
> 
> Adds `overflow-hidden` to the mobile `FeaturesBlocks` wrapper to clip overflow, and gives the mobile footer `relative z-10` so it reliably stacks above any overlapping content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498cd2153528b79e39e2deb287cfb52175d125bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->